### PR TITLE
kubelet 1.21.4

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,9 +1,9 @@
 FROM docker.io/alpine:3.14 AS fetcher
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
-ARG KUBELET=v1.22.1
+ARG KUBELET=v1.21.4
 ARG ARCH=amd64
-ARG SHA=53b44fbf58308c18b478ced5629a82d01c67dd6ae5be9559a2d65edae339983bff4d143b1bde062f5d8202ec8241e45da3b087af1fb0aea35afb1812a26450d1
+ARG SHA=de99c3ec833401de7165b16aec3893fec002e327e49b42d397bc2475c4215173b36029459d96a6e63feb285a6c54770fd9d62f423c3081fbf4d537557f4c67c8
 
 RUN apk add curl && \
   curl -L https://dl.k8s.io/${KUBELET}/kubernetes-node-linux-${ARCH}.tar.gz -o node.tar.gz && \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,9 +1,9 @@
 FROM docker.io/alpine:3.14 AS fetcher
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
-ARG KUBELET=v1.22.1
+ARG KUBELET=v1.21.4
 ARG ARCH=arm64
-ARG SHA=eb6a5cb5270a662a79302472a347a5486b3e0689c0c8ea0ceb62e83f72c043dc3b15ee3d5ec40790a1754748950208d8b5818b3f1d64e44a881720a78f50cc7e
+ARG SHA=1ed7193022eebedc988fe64257c11788b6104054c6496768a6f704c98c54573f9e98ea588f09715460c1c5f6435db94b6c49d539f4dd4fcef5555ea13313f614
 
 RUN apk add curl && \
   curl -L https://dl.k8s.io/${KUBELET}/kubernetes-node-linux-${ARCH}.tar.gz -o node.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -35,3 +35,29 @@ Kubelet also requires:
 ### kubectl
 
 `kubectl` (no dependencies) is also included for convenience (e.g. use pre-pulled Kubelet image to `kubectl delete node` on preemption).
+
+## Build Image
+
+You can use `make image-arm64` or `make image-amd64` to create images. However this requires `buildah` to be installed.
+
+Alternate build instructions if you don't have `buildah` installed:
+
+```
+export IMAGE_URL= quay.io/kinvolk/kubelet:v1.21.4
+
+export ARCH=amd64
+docker buildx build --load -t $IMAGE_URL-$ARCH -f Dockerfile.$ARCH --platform linux/$ARCH .
+
+export ARCH=arm64
+docker buildx build --load -t $IMAGE_URL-$ARCH -f Dockerfile.$ARCH --platform linux/$ARCH .
+```
+
+To create, annotate and publish manifests:
+```
+docker manifest create $IMAGE_URL --amend $IMAGE_URL-amd64 --amend $IMAGE_URL-arm64
+
+docker manifest annotate $IMAGE_URL $IMAGE_URL-amd64 --arch=amd64 --os=linux
+docker manifest annotate $IMAGE_URL $IMAGE_URL-arm64 --arch=arm64 --os=linux
+
+docker manifest push $IMAGE_URL
+```


### PR DESCRIPTION
Update Kubelet to 1.21.4

Alternate build instructions if buildah is not installed

```
export IMAGE_URL= quay.io/kinvolk/kubelet:v1.21.4

export ARCH=amd64
docker buildx build --load -t $IMAGE_URL-$ARCH -f Dockerfile.$ARCH --platform linux/$ARCH .

export ARCH=arm64
docker buildx build --load -t $IMAGE_URL-$ARCH -f Dockerfile.$ARCH --platform linux/$ARCH .
```

To create, annotate and publish manifests:
```
docker manifest create $IMAGE_URL --amend $IMAGE_URL-amd64 --amend $IMAGE_URL-arm64

docker manifest annotate $IMAGE_URL $IMAGE_URL-amd64 --arch=amd64 --os=linux
docker manifest annotate $IMAGE_URL $IMAGE_URL-arm64 --arch=arm64 --os=linux

docker manifest push $IMAGE_URL
```

Signed-off-by: Imran Pochi <imran@kinvolk.io>